### PR TITLE
Tweak examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,1 +1,4 @@
 To run `Basic` example: copy `basic_in.urp.in` to `basic_in.urp` and fill in your GitHub application details.
+
+You can create an OAuth App in https://github.com/settings/developers, make sure to set
+*Authorization callback URL* to `http://localhost:8080/G/authorized/http.3A.2F.2Flocalhost.3A8080.2Fafter` in application settings.

--- a/src/ur/lib.urp
+++ b/src/ur/lib.urp
@@ -6,6 +6,7 @@ effectful WorldFfi.post
 $/char
 $/string
 $/json
+$/monad
 urls
 oauth
 github


### PR DESCRIPTION
Add a mention how to configure Github OAuth App to README and add `$/monad` to `lib.urp` to make sure it builds.

I was using the following nix expression to build:
```nix
{ stdenv, fetchgit, autoreconfHook, curl, urweb }:

stdenv.mkDerivation {
  name = "urweb-world";

  buildInputs = [
    autoreconfHook
    urweb
  ];

  propagatedBuildInputs = [
    curl
  ];

  preConfigure = ''
    export CFLAGS="-I${urweb}/include/urweb"
  '';

  src = ./world;
  # src = fetchgit {
  #   inherit (builtins.fromJSON (builtins.readFile ./world.json)) url rev sha256;
  # };
}
```