### PR TITLE
Add convenient `add_params_to_url` function

### DIFF
--- a/src/ur/oauth.ur
+++ b/src/ur/oauth.ur
@@ -152,18 +152,13 @@ functor MakeDyn(M : sig
             dml (INSERT INTO states(State, Expires) VALUES({[state]}, {[addSeconds tm 300]}));
             settings <- settings;
 
-            redirect (bless (show settings.AuthorizeUrl
-                             ^ "?client_id=" ^ urlencode settings.ClientId
-                             ^ "&redirect_uri=" ^ urlencode (show (effectfulUrl authorized))
-                             ^ "&state=" ^ show state
-                             ^ "&response_type=code"
-                             ^ (case scope of
-                                    None => ""
-                                  | Some scope => "&" ^ Option.get "scope" nameForScopeParameter
-                                                  ^ "=" ^ urlencode scope)
-                             ^ (case hosted_domain of
-                                    None => ""
-                                  | Some hd => "&hd=" ^ urlencode hd)))
+            redirect (add_params_to_url settings.AuthorizeUrl
+              (("client_id", Some settings.ClientId),
+               ("redirect_uri", Some (show (effectfulUrl authorized))),
+               ("state", Some (show state)),
+               ("response_type", Some "code"),
+               (Option.get "scope" nameForScopeParameter, scope),
+               ("hd", hosted_domain)))
         end
 end
 

--- a/src/ur/urls.ur
+++ b/src/ur/urls.ur
@@ -134,3 +134,13 @@ fun base64url_encode' (getChar : int -> char) (urlVersion : bool) (len : int) =
 fun base64url_encode s = base64url_encode' (String.sub s) True (String.length s)
 fun base64url_encode_signature s = base64url_encode' (WorldFfi.byte s) True (WorldFfi.length s)
 fun base64_encode_signature s = base64url_encode' (WorldFfi.byte s) False (WorldFfi.length s)
+
+fun add_params_to_url [r] fl base_url params =
+    (* If there's a '?' in the base url, then it already has params, and we continue with '&'. *)
+    let val initialPrefix = if String.all (fn ch => ch <> #"?") (show base_url) then "?" else "&"
+        fun foldFun [nm ::_] [rest ::_] [[nm] ~ rest] (nm, op) (prefix, rst) = case op of
+                  None   => (prefix, rst)
+                | Some p => ("&", rst ^ prefix ^ nm ^ "=" ^ urlencode p)
+        val encoded_params = @foldUR [(string * option string)] [fn _ => (string * string)] foldFun (initialPrefix, "") fl params
+    in bless (show base_url ^ encoded_params.2)
+    end

--- a/src/ur/urls.urs
+++ b/src/ur/urls.urs
@@ -4,3 +4,10 @@ val urldecode : string -> string
 val base64url_encode : string -> string
 val base64url_encode_signature : WorldFfi.signatur -> string
 val base64_encode_signature : WorldFfi.signatur -> string
+
+(* Takes a base URL along with a record of name/value pairs and formats the
+   pairs into the typical "base_url?nm1=val1&nm2=val2...", properly URL encoding
+   the given strings.
+   The base URL may already name/value pairs.
+   If the value is `None`, then the name/value pair is omitted from the result *)
+val add_params_to_url : r ::: {Unit} -> folder r -> url -> $(mapU (string * option string) r) -> url


### PR DESCRIPTION
It does what it says.  This is partially an exercise that I came up with for myself, but also it seems like a nice (if simple) abstraction.  I've only put it to use in `oauth.ur`, but there are a few other places it could be used if we'd like.

I've done a bit of testing, and it seems like I haven't broken anything.  It would be nice to set up some CI though.